### PR TITLE
Fix/UI move to top bottom non swap

### DIFF
--- a/src/Tkmm/ViewModels/Pages/HomePageViewModel.cs
+++ b/src/Tkmm/ViewModels/Pages/HomePageViewModel.cs
@@ -1,4 +1,4 @@
-﻿#if RELEASE
+#if RELEASE
 using Avalonia.Threading;
 #endif
 using Avalonia.Controls;
@@ -70,13 +70,32 @@ public partial class HomePageViewModel : ObservableObject
     [RelayCommand]
     private static void MoveToTop()
     {
-        TKMM.ModManager.GetCurrentProfile().MoveToTop();
+        var profile = TKMM.ModManager.GetCurrentProfile();
+        var target = profile.Selected;
+        if (target is null) return;
+
+        var mods = profile.Mods;
+        int currentIndex = mods.IndexOf(target);
+        if (currentIndex <= 0) return;
+
+        mods.RemoveAt(currentIndex);
+        mods.Insert(0, target);
     }
 
     [RelayCommand]
     private static void MoveToBottom()
     {
-        TKMM.ModManager.GetCurrentProfile().MoveToBottom();
+        var profile = TKMM.ModManager.GetCurrentProfile();
+        var target = profile.Selected;
+        if (target is null) return;
+
+        var mods = profile.Mods;
+        int currentIndex = mods.IndexOf(target);
+        int lastIndex = mods.Count - 1;
+        if (currentIndex < 0 || currentIndex >= lastIndex) return;
+
+        mods.RemoveAt(currentIndex);
+        mods.Add(target);
     }
 
     [RelayCommand]


### PR DESCRIPTION
Formerly these buttons swapped the selected mod with the top/bottom.
This code should instead push the mod to the top/bottom without affecting any other mod orders.